### PR TITLE
Allow connection with MongoDb URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ key in the dictionary.
 ###To run mongoexportcsv : 
 
 	1) Clone the git repository
-	2) python mongoexportcsv.py <db_name> <collection_name> <path_to_output_file_name>
+	2) python mongoexportcsv.py <db_name_or_mongodb_uri> <collection_name> <path_to_output_file_name>
 
 ###Notes:
+
+The first of the arguments can the name of your database or a complete mongoDb URI: `mongodb://username:password@host:port/databaseName`
 
 As you can see, this is clearly barebones and I've just finished coding it.
 I'll be adding features like using baseCommands to specify command-line args

--- a/mongoexportcsv.py
+++ b/mongoexportcsv.py
@@ -17,8 +17,13 @@ class generic_converter:
                 self.header_dict[name_var + '||' + element] = test_dict[element]
 
     def converter_main(self, csv_writer):
-        client = MongoClient()
-        db = client[sys.argv[1]]
+        mongo_uri_or_db_name = sys.argv[1]
+        if mongo_uri_or_db_name.startswith("mongodb://"): # mongodb uri given
+            client = MongoClient(mongo_uri_or_db_name)
+            db = client[mongo_uri_or_db_name.split("/")[-1]]
+        else: # database name given
+            client = MongoClient()
+            db = client[mongo_uri_or_db_name]
         collection_obj = db[sys.argv[2]]
         cursor_records = collection_obj.find()
         header_list = []


### PR DESCRIPTION
With this change, the first argument given to the python script can be a MongoDb URI, which allows to create a MongoClient instance from a remote Host and with username-pwd authentication.
